### PR TITLE
Potential fix for code scanning alert no. 16: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Spread Secrets to Environment Variables
         uses: oNaiPs/secrets-to-env-action@v1
         with:
-          secrets: ${{ toJSON(secrets) }}
+          secrets: |
+            SECRET_API_KEY=${{ secrets.SECRET_API_KEY }}
+            SECRET_DB_PASSWORD=${{ secrets.SECRET_DB_PASSWORD }}
 
       - name: Deploy to Production
         id: deploy


### PR DESCRIPTION
Potential fix for [https://github.com/bible-on-site/bible-on-site/security/code-scanning/16](https://github.com/bible-on-site/bible-on-site/security/code-scanning/16)

To fix the issue, we need to replace the use of `toJSON(secrets)` with explicit references to only the secrets required by the workflow. This ensures that only the necessary secrets are passed to the workflow runner, adhering to the principle of least privilege. In this case, we will identify the specific secrets needed for the deployment process and explicitly reference them in the workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
