### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
   setup_env:
     name: Setup Environment Variables
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       api_directory: ${{ env.API_DIRECTORY }} # a workaround for places where only needs.<job_id>.<output> is allowed
       api_playwright_version: ${{ steps.get_api_playwright_version.outputs.PLAYWRIGHT_VERSION }}


### PR DESCRIPTION
Potential fix for [https://github.com/bible-on-site/bible-on-site/security/code-scanning/14](https://github.com/bible-on-site/bible-on-site/security/code-scanning/14)

To fix the issue, add a `permissions` block to the `setup_env` job to explicitly limit the `GITHUB_TOKEN` permissions to the least privilege required. Based on the job's functionality, it only needs read access to repository contents. This change ensures the workflow is secure and adheres to best practices.

The `permissions` block should be added directly under the `setup_env` job definition in the `.github/workflows/ci.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
