### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -1,5 +1,8 @@
 name: Shared CI Components
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/bible-on-site/bible-on-site/security/code-scanning/13](https://github.com/bible-on-site/bible-on-site/security/code-scanning/13)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs, as none of the jobs require additional permissions beyond reading repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
