### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # TODO: cleanup artifacts using geekyeggo/delete-artifact
 name: Continous Integration
+permissions:
+  contents: read
 
 on:
   # Better practice is to run on any push instead of just either master push or PR.


### PR DESCRIPTION
Potential fix for [https://github.com/bible-on-site/bible-on-site/security/code-scanning/3](https://github.com/bible-on-site/bible-on-site/security/code-scanning/3)

In general, this issue is fixed by explicitly specifying a restrictive `permissions` block either at the workflow root (applies to all jobs without their own `permissions`) or on the individual job, so that `GITHUB_TOKEN` does not default to broad read-write scopes.

The minimal, non-disruptive fix here is to add a root-level `permissions` block just under `name: Continous Integration`, setting `contents: read` which is sufficient for `actions/checkout` and typical CI read operations, and already used by the `determine_baseline_availability` job. This will apply to `setup_env`, `determine_website_changes`, `determine_api_changes`, and any other jobs that don’t override `permissions`. We leave the existing `permissions` block on `determine_baseline_availability` as-is; job-level settings will continue to override the workflow default where specified. No imports or additional methods are required, as this is purely a YAML configuration change in `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 2 (`name: Continous Integration`) and line 4 (`on:`). This sets a safe default for all jobs, including `determine_website_changes`, without altering their functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
