### PR TITLE
ci: add version verification comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 # TODO: cleanup artifacts using geekyeggo/delete-artifact
+# Version verification: Prevents duplicate version releases by verifying module versions are bumped
 name: Continuous Integration
 permissions:
   contents: read


### PR DESCRIPTION
CI-only change to test that version verification is skipped when only CI files change (no module changes).