### PR TITLE
chore(app): bump version to 4.0.39

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -30,11 +30,11 @@
 		<ApplicationId>com.tanah.daily929</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>4.0.38</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>4.0.39</ApplicationDisplayVersion>
 		<!-- Windows MSIX requires each version component ≤65535, so we use a separate incrementing value -->
 		<!-- Android versionCode can be large, continuing from Play Store's 40000017 -->
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">40000051</ApplicationVersion>
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">51</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">40000052</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">52</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<!-- WindowsPackageType: None for local dev, MSIX for Store publishing (set via CLI: /p:WindowsPackageType=MSIX) -->


### PR DESCRIPTION
Bump app version to trigger iOS build with new build number for TestFlight.