### PR TITLE
fix(cd): use Fastfile for pilot distribute with localized_app_info

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -245,6 +245,36 @@ jobs:
           app_identifier("com.tanah.daily929")
           EOF
 
+          # Create Fastfile with custom lane for distribution
+          cat > fastlane/Fastfile << 'FASTFILE'
+          default_platform(:ios)
+
+          platform :ios do
+            desc "Distribute an existing build to external testers"
+            lane :distribute_existing do |options|
+              api_key = app_store_connect_api_key(
+                key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+                issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+                key_filepath: ENV["API_KEY_P8_PATH"]
+              )
+
+              pilot(
+                api_key: api_key,
+                app_identifier: "com.tanah.daily929",
+                app_platform: "ios",
+                distribute_external: true,
+                groups: [ENV["TESTFLIGHT_BETA_GROUP"]],
+                localized_app_info: {
+                  "default" => {
+                    "description" => "929 - תנ\"ך על הפרק: Daily Bible study app following the 929 project curriculum.",
+                    "feedback_email" => "support@929.org.il"
+                  }
+                }
+              )
+            end
+          end
+          FASTFILE
+
           # Try to upload, and if build already exists, just distribute the existing one
           UPLOAD_OUTPUT=$(fastlane pilot upload \
             --ipa "${{ steps.find_ipa.outputs.IPA_FILE }}" \
@@ -256,14 +286,10 @@ jobs:
             --beta_app_feedback_email "support@929.org.il" \
             --changelog "Automated build v${{ env.MODULE_VERSION }}" 2>&1) || {
             if echo "$UPLOAD_OUTPUT" | grep -q "bundle version must be higher"; then
-              echo "Build already exists in TestFlight. Distributing existing build..."
-              fastlane pilot distribute \
-                --api_key_path "${{ env.API_KEY_PATH }}" \
-                --app_identifier "com.tanah.daily929" \
-                --app_platform ios \
-                --distribute_external true \
-                --groups "${TESTFLIGHT_BETA_GROUP}" \
-                --localized_app_info '{"default": {"description": "929 - תנ\"ך על הפרק: Daily Bible study app following the 929 project curriculum.", "feedback_email": "support@929.org.il"}}'
+              echo "Build already exists in TestFlight. Distributing existing build using Fastfile..."
+              # Extract the raw .p8 key path for the Fastfile
+              export API_KEY_P8_PATH="$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+              fastlane ios distribute_existing
             else
               echo "$UPLOAD_OUTPUT"
               exit 1
@@ -272,7 +298,7 @@ jobs:
           echo "$UPLOAD_OUTPUT"
 
       - name: Cleanup
-        if: always()
+        if: always:()
         run: rm -rf $HOME/private_keys
 
       - name: Deployment Summary


### PR DESCRIPTION
CLI arguments for `--localized_app_info` don't work properly with `pilot distribute`. Using a Fastfile with Ruby hash syntax instead, which is the recommended approach for complex parameters.