### PR TITLE
fix(cd): fix syntax error - always() not always:()

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -298,7 +298,7 @@ jobs:
           echo "$UPLOAD_OUTPUT"
 
       - name: Cleanup
-        if: always:()
+        if: always()
         run: rm -rf $HOME/private_keys
 
       - name: Deployment Summary


### PR DESCRIPTION
Fixes typo in workflow syntax that was preventing CD dispatch.