### PR TITLE
fix(cd): add skip_submission and distribute_only for pilot distribute

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -262,6 +262,8 @@ jobs:
                 api_key: api_key,
                 app_identifier: "com.tanah.daily929",
                 app_platform: "ios",
+                skip_submission: true,
+                distribute_only: true,
                 distribute_external: true,
                 groups: [ENV["TESTFLIGHT_BETA_GROUP"]],
                 localized_app_info: {


### PR DESCRIPTION
When using pilot to distribute an already-uploaded build, we need to set skip_submission: true and distribute_only: true to avoid the 'No ipa or pkg file given' error.