### PR TITLE
fix(cd): use Apple-compliant phone format for TestFlight

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -245,7 +245,7 @@ jobs:
             --groups "${TESTFLIGHT_BETA_GROUP}" \
             --beta_app_description "929 - תנ\"ך על הפרק: Daily Bible study app following the 929 project curriculum. Study one chapter of Tanakh every day with commentary and insights." \
             --beta_app_feedback_email "tanah.site@gmail.com" \
-            --beta_app_review_info '{"contact_email":"tanah.site@gmail.com","contact_first_name":"929","contact_last_name":"Support","contact_phone":"+1 (555) 555-5555"}' \
+            --beta_app_review_info '{"contact_email":"tanah.site@gmail.com","contact_first_name":"929","contact_last_name":"Support","contact_phone":"+1 555 555 5555"}' \
             --changelog "Automated build v${{ env.MODULE_VERSION }}"
 
       - name: Cleanup

--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -30,11 +30,11 @@
 		<ApplicationId>com.tanah.daily929</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>5.0.12</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>5.0.13</ApplicationDisplayVersion>
 		<!-- Windows MSIX requires each version component ≤65535, so we use a separate incrementing value -->
 		<!-- Android versionCode can be large, continuing from Play Store's 40000017 -->
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000013</ApplicationVersion>
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">13</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000014</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">14</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<!-- WindowsPackageType: None for local dev, MSIX for Store publishing (set via CLI: /p:WindowsPackageType=MSIX) -->


### PR DESCRIPTION
Phone format '+1 (555) 555-5555' was rejected. Apple requires format '+COUNTRY AREA EXCHANGE LINE' with spaces only (e.g., '+44 844 209 0611').