### PR TITLE
fix(cd): use plain phone format per fastlane docs

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -245,7 +245,7 @@ jobs:
             --groups "${TESTFLIGHT_BETA_GROUP}" \
             --beta_app_description "929 - תנ\"ך על הפרק: Daily Bible study app following the 929 project curriculum. Study one chapter of Tanakh every day with commentary and insights." \
             --beta_app_feedback_email "tanah.site@gmail.com" \
-            --beta_app_review_info '{"contact_email":"tanah.site@gmail.com","contact_first_name":"929","contact_last_name":"Support","contact_phone":"+1 555 555 5555"}' \
+            --beta_app_review_info '{"contact_email":"tanah.site@gmail.com","contact_first_name":"Dorad","contact_last_name":"Levinshtein","contact_phone":"37257078640"}' \
             --changelog "Automated build v${{ env.MODULE_VERSION }}"
 
       - name: Cleanup

--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -30,11 +30,11 @@
 		<ApplicationId>com.tanah.daily929</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>5.0.14</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>5.0.15</ApplicationDisplayVersion>
 		<!-- Windows MSIX requires each version component ≤65535, so we use a separate incrementing value -->
 		<!-- Android versionCode can be large, continuing from Play Store's 40000017 -->
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000015</ApplicationVersion>
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">15</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000016</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">16</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<!-- WindowsPackageType: None for local dev, MSIX for Store publishing (set via CLI: /p:WindowsPackageType=MSIX) -->


### PR DESCRIPTION
Per [fastlane pilot docs](https://docs.fastlane.tools/actions/pilot/), the `contact_phone` field should use a plain format like `5558675309` without country code prefix or special formatting.

Previous attempts:
- `+972000000000` - rejected
- `+1 (555) 555-5555` - rejected
- `+1 555 555 5555` - rejected

This follows the exact format from fastlane docs example: `contact_phone: "5558675309"`

Also bumps version to 5.0.15 (build 16) for fresh CD trigger.