### PR TITLE
fix(cd-app): handle TestFlight submission limit gracefully

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,3 +37,23 @@ When using a tool/library/framework for the first time:
   2. Fix the issue or ask clarifying questions if unsure
   3. Never say "this is unrelated" and move on without resolution
 - Use of client components in `web/bible-on-site` is forbidden unless explicitly requested
+
+### GitHub Issue Creation
+
+When creating GitHub issues, **always** include:
+
+1. **Priority label** (required): `P1` (Top Priority), `P2` (Prioritized), or `P3` (Nice to have)
+2. **Difficulty label** (required): `D1` (Low), `D2` (Medium), `D3` (High), or `D4` (Huge)
+3. **Project** (required): Add to the appropriate project:
+   - `App` (project #4) — for mobile app issues
+   - `API` (project #3) — for backend API issues
+   - `website` (project #2) — for frontend website issues
+   - `Data` (project #5) — for data pipeline issues
+   - `Admin` (project #6) — for admin portal issues
+
+Use gh CLI to add labels and project:
+
+```bash
+gh issue edit <number> --repo bible-on-site/bible-on-site --add-label "P3,D1"
+gh project item-add <project-number> --owner bible-on-site --url <issue-url>
+```

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -234,11 +234,16 @@ jobs:
       - name: Install Fastlane
         run: gem install fastlane -NV
 
+      # TODO: Split upload and distribution into separate workflows (see #1183)
+      # This stdout checker is a workaround for Apple's submission limit errors -
+      # we consider the job successful if the build was processed, even if
+      # external distribution fails due to rate limits.
       - name: Upload to TestFlight and Distribute to Beta Group
         env:
           TESTFLIGHT_BETA_GROUP: ${{ secrets.TESTFLIGHT_BETA_GROUP_NAME }}
         run: |
-          fastlane pilot upload \
+          set +e
+          OUTPUT=$(fastlane pilot upload \
             --ipa "${{ steps.find_ipa.outputs.IPA_FILE }}" \
             --api_key_path "${{ env.API_KEY_PATH }}" \
             --skip_waiting_for_build_processing false \
@@ -247,7 +252,20 @@ jobs:
             --beta_app_description "בכ\"ט כסלו תשע\"ה(21 דצמ' 14) התחילה תכנית לימוד תנ\"ך יומי של משרד החינוך, פרק ליום. כחודש לאחר מכן עלה לרשת אתר לימוד תנך באותו פורמט אשר מתעדכן מיום ליום במאמרים של רבנים. כמו כן יש רעיונות נוספים שעתידים להתחדש, תעקבו אחרינו! לימוד פורה, תנך.co.il" \
             --beta_app_feedback_email "tanah.site@gmail.com" \
             --beta_app_review_info '{"contact_email":"tanah.site@gmail.com","contact_first_name":"Dorad","contact_last_name":"Levinshtein","contact_phone":"+372 5707 8640"}' \
-            --changelog "Automated build v${{ env.MODULE_VERSION }}"
+            --changelog "Automated build v${{ env.MODULE_VERSION }}" 2>&1)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+
+          if echo "$OUTPUT" | grep -q "Successfully finished processing the build"; then
+            echo "✅ Build was uploaded and processed successfully"
+            if [ $EXIT_CODE -ne 0 ]; then
+              echo "::warning::Distribution may have failed (e.g., submission limits) - manual distribution may be required"
+            fi
+            exit 0
+          else
+            echo "❌ Build upload/processing failed"
+            exit $EXIT_CODE
+          fi
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Summary
- Add stdout checker for "Successfully finished processing the build" to pass job even if external distribution fails due to Apple rate limits
- Add TODO referencing #1183 for proper workflow split
- Add GitHub issue creation requirements to copilot-instructions

## Test plan
- [x] Workflow syntax is valid
- [ ] Re-run failed deployment to verify fix