### PR TITLE
fix(ci): add id-token permission for AWS OIDC auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
     permissions:
       contents: write
       actions: read
+      id-token: write # Required by shared-dockerize.yml
     secrets: inherit
     uses: ./.github/workflows/shared-dockerize.yml
     with:

--- a/.github/workflows/shared-dockerize.yml
+++ b/.github/workflows/shared-dockerize.yml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.package.outputs.docker_artifact_name }}
 permissions:
   contents: write
-  # Note: id-token: write must be granted by the calling workflow for AWS OIDC auth
+  id-token: write # Required for AWS OIDC authentication
 env:
   IS_NPM: ${{ inputs.module_directory == 'web/bible-on-site' }}
   IS_CARGO: ${{ inputs.module_directory == 'web/api' }}


### PR DESCRIPTION
The reusable workflow needs id-token permission to authenticate with AWS via OIDC.

Both package_website and package_api callers now grant this permission.

Made with [Cursor](https://cursor.com)