### PR TITLE
fix(ci): disable simulator destination resolution for iOS build

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -39,11 +39,11 @@
 		<ApplicationId>com.tanah.daily929</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>5.0.31</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>5.0.32</ApplicationDisplayVersion>
 		<!-- Windows MSIX requires each version component ≤65535, so we use a separate incrementing value -->
 		<!-- Android versionCode can be large, continuing from Play Store's 40000017 -->
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000031</ApplicationVersion>
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">31</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000032</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">32</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<!-- WindowsPackageType: None for local dev, MSIX for Store publishing (set via CLI: /p:WindowsPackageType=MSIX) -->

--- a/app/devops/Build.Package.cs
+++ b/app/devops/Build.Package.cs
@@ -203,7 +203,11 @@ partial class Build
             ["TargetFramework"] = "net9.0-ios",
             ["ArchiveOnBuild"] = "true",
             ["BuildIpa"] = "true",
-            ["IpaPackageDir"] = $"{ArtifactsDirectory}/"
+            ["IpaPackageDir"] = $"{ArtifactsDirectory}/",
+            // Skip simulator runtime validation - the .NET iOS SDK bundles iphonesimulator SDK 23A339 (iOS 17)
+            // but CI runners only have iOS 18.x/26.x runtimes installed, causing actool to fail
+            ["SupportedOSPlatformVersion"] = "17.0",
+            ["_ExcludeSimulatorArchitectures"] = "true"
         };
 
         // Add code signing configuration


### PR DESCRIPTION
## Summary
- Add MSBuild properties to skip simulator runtime validation for iOS build
- Bump version to 5.0.32

## Problem
The .NET iOS SDK bundles `iphonesimulator SDK 23A339` (iOS 17) but CI runners only have iOS 18.x/26.x simulator runtimes installed. This causes `actool` to fail with:
```
No simulator runtime version from ["22F77", "22G86", "23B86", "23C54"] available to use with iphonesimulator SDK version 23A339
```

## Solution
Add MSBuild properties in `Build.Package.cs` to exclude simulator architectures:
- `SupportedOSPlatformVersion=17.0`
- `_ExcludeSimulatorArchitectures=true`

## Test Results
Successfully tested in `test/ios-package-fix` branch - iOS packaging completed successfully after ~10 minutes (vs failing after ~1 minute before).

Successful run: https://github.com/bible-on-site/bible-on-site/actions/runs/21626726713/job/62328685812