### PR TITLE
fix(app): fully qualify Application.Current to fix iOS build

### DIFF
--- a/app/BibleOnSite/Pages/PerekPage.xaml.cs
+++ b/app/BibleOnSite/Pages/PerekPage.xaml.cs
@@ -653,7 +653,7 @@ public partial class PerekPage : ContentPage
 
         // Change back to hamburger
         CircularMenuButton.Text = "☰";
-        CircularMenuButton.BackgroundColor = (Color)Application.Current!.Resources["Primary"];
+        CircularMenuButton.BackgroundColor = (Color)Microsoft.Maui.Controls.Application.Current!.Resources["Primary"];
 
         // Animate FAB rotation and fade out all buttons
         var animations = new List<Task>
@@ -1318,7 +1318,7 @@ public partial class PerekPage : ContentPage
                 b.InputTransparent = true;
             }
             CircularMenuButton.Text = "☰";
-            CircularMenuButton.BackgroundColor = (Color)Application.Current!.Resources["Primary"];
+            CircularMenuButton.BackgroundColor = (Color)Microsoft.Maui.Controls.Application.Current!.Resources["Primary"];
             CircularMenuButton.Rotation = 0;
         }
 


### PR DESCRIPTION
## Summary
- On iOS, the unqualified `Application` in `PerekPage.xaml.cs` resolves to `UIKit.UIApplication` (due to `using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific`) instead of `Microsoft.Maui.Controls.Application`, causing `CS0117: 'Application' does not contain a definition for 'Current'`.
- Fully qualifies both usages as `Microsoft.Maui.Controls.Application.Current` to match the pattern already used elsewhere in the same file.

## Test plan
- iOS packaging step in CI should now pass (was failing with CS0117).

Made with [Cursor](https://cursor.com)