### PR TITLE
chore(web): bump website version to 0.2.256

### DIFF
--- a/web/bible-on-site/package.json
+++ b/web/bible-on-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bible-on-site",
-	"version": "0.2.255",
+	"version": "0.2.256",
 	"private": true,
 	"license": "MIT",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Version 0.2.255 was already released from the decode-slug merge (PR #1332)
- This bumps to 0.2.256 so the Lambda parser + TOC styling + flip-book alpha.34 changes from PR #1338 get a new release

## Test plan
- [x] Pre-commit version check passes (0.2.256 > 0.2.255)

Made with [Cursor](https://cursor.com)