### PR TITLE
chore(bulletin): trigger Package Bulletin on master

### DIFF
--- a/web/bulletin/Dockerfile
+++ b/web/bulletin/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Lambda-compatible binary (musl target).
-# Build context must be web/ to access shared api/entities/ dependency.
+# Build context must be web/ — ensure bulletin/ is included in web/.dockerignore.
 
 ARG RUST_VERSION=1.93.1
 


### PR DESCRIPTION
## Summary
Trivial Dockerfile comment update to trigger bulletin module change detection so Package Bulletin runs on master with the dockerignore fix from #1371.

## Context
PR #1369 merged but Package Bulletin failed due to missing bulletin/ in .dockerignore. PR #1371 fixed the .dockerignore but didn't trigger bulletin changes. This PR triggers the bulletin change detection.

Made with [Cursor](https://cursor.com)