### PR TITLE
fix(devops): use parseSync to fix top-level await in bump-cargo-version

### DIFF
--- a/devops/bump-cargo-version.ts
+++ b/devops/bump-cargo-version.ts
@@ -18,7 +18,7 @@ import { resolveModule, type ModulePath, type ModuleName } from "./get-module-ve
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 
-const argv = await yargs(hideBin(process.argv))
+const argv = yargs(hideBin(process.argv))
 	.option("module", {
 		type: "string",
 		demandOption: true,
@@ -26,7 +26,7 @@ const argv = await yargs(hideBin(process.argv))
 		choices: ["api", "bulletin", "web/api", "web/bulletin"],
 	})
 	.strict()
-	.parse();
+	.parseSync();
 
 const moduleConfig = resolveModule(argv.module as ModulePath | ModuleName);
 const cargoTomlPath = join(REPO_ROOT, moduleConfig.versionFile);


### PR DESCRIPTION
## Summary
- Replace `await .parse()` with `.parseSync()` in `devops/bump-cargo-version.ts`

## Context
The Bump Versions CI job failed because tsx treats `.ts` files as CJS (no `"type": "module"` in devops `package.json`), and CJS doesn't support top-level `await`.

## Test plan
- [ ] CI passes
- [ ] Bump Versions succeeds on next bulletin release

Made with [Cursor](https://cursor.com)