### PR TITLE
refactor(ci): run App iOS CI only on PRs, align with packaging workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1410,7 +1410,9 @@ jobs:
     name: App iOS CI
     runs-on: macos-15
     needs: [setup_env, determine_app_changes]
-    if: ${{ always() && !cancelled() && !failure() && (needs.determine_app_changes.outputs.module_changed == 'true' || needs.determine_app_changes.outputs.ci_changed == 'true') }}
+    # Only on PRs — on master, Package iOS (IPA) already validates the full iOS build.
+    # TODO(#1018): when upgrading to .NET 10, verify workload install flags still work.
+    if: ${{ github.event_name == 'pull_request' && always() && !cancelled() && !failure() && (needs.determine_app_changes.outputs.module_changed == 'true' || needs.determine_app_changes.outputs.ci_changed == 'true') }}
     defaults:
       run:
         working-directory: ${{ env.APP_DIRECTORY }}
@@ -1421,7 +1423,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.head_ref }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -1437,13 +1439,8 @@ jobs:
             ${{ runner.os }}-nuget-maui-ios-
             ${{ runner.os }}-nuget-
 
-      - name: Pin .NET 9 SDK
-        run: |
-          echo '{"sdk":{"version":"9.0.0","rollForward":"latestFeature"}}' > $GITHUB_WORKSPACE/global.json
-          echo "Pinned SDK: $(dotnet --version)"
-
       - name: Install MAUI workload
-        run: dotnet workload install maui-ios
+        run: dotnet workload install maui-ios --skip-manifest-update
 
       - name: Decompress perushim notes for iOS ODR asset catalog
         working-directory: ${{ env.APP_DIRECTORY }}/BibleOnSite
@@ -1976,8 +1973,9 @@ jobs:
           fi
 
           if [ "$APP_MODULE_CHANGED" = "true" ] || [ "$CI_CHANGED" = "true" ]; then
-            APP_IOS_STATUS=$([ "${{ needs.app_ios_ci.result }}" = "success" ] && echo "success" || echo "failure") # Generated
-            if [ "$APP_IOS_STATUS" = "failure" ]; then
+            APP_IOS_RESULT="${{ needs.app_ios_ci.result }}"
+            # App iOS CI only runs on PRs; on master it's skipped (Package iOS covers it)
+            if [ "$APP_IOS_RESULT" != "success" ] && [ "$APP_IOS_RESULT" != "skipped" ]; then
               echo "App iOS CI failed"
               echo "Overall status: failure"
               exit 1


### PR DESCRIPTION
## Summary
- Skip `app_ios_ci` on master — `Package iOS (IPA)` already validates the full iOS build there (9 min vs 45 min for the same coverage).
- Use `--skip-manifest-update` matching the packaging workflow approach instead of downloading fresh manifests (major speed improvement).
- Remove `global.json` pin — unnecessary with `--skip-manifest-update`.
- Accept `skipped` result in `cross_module_ci` on master.

## Test plan
- [ ] PR CI passes (App iOS CI runs on this PR)
- [ ] Verify App iOS CI completes faster (~10 min vs ~45 min)

Made with [Cursor](https://cursor.com)