### PR TITLE
fix(admin): correct Docker build output path from .output to dist

### DIFF
--- a/web/admin/Dockerfile
+++ b/web/admin/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache curl
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 adminjs
 
-COPY --from=builder --chown=adminjs:nodejs /app/admin/.output ./.output
+COPY --from=builder --chown=adminjs:nodejs /app/admin/dist ./dist
 
 USER adminjs
 
@@ -32,4 +32,4 @@ EXPOSE 3101
 ENV PORT=3101
 ENV HOST="0.0.0.0"
 
-CMD ["node", ".output/server/index.mjs"]
+CMD ["node", "dist/server/server.js"]

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -9,7 +9,7 @@
 		"dev:with-env": "npm run docker:up && npm run db:populate:dev && npm run s3:populate:dev && npm run dev:app",
 		"dev:full": "npm run docker:up && npm run dev",
 		"build": "vite build",
-		"start": "node .output/server/index.mjs",
+		"start": "node dist/server/server.js",
 		"lint": "biome lint",
 		"format": "biome format --write",
 		"check": "biome check --write",


### PR DESCRIPTION
## Summary
- TanStack Start with Vite plugin outputs to `dist/`, not `.output/` (Vinxi convention)
- Update Dockerfile COPY path and CMD entry point to use `dist/server/server.js`
- Update `start` script in package.json to match

## Root Cause
The admin Dockerfile was written assuming Vinxi's `.output/` convention, but the project uses TanStack Start's Vite plugin which outputs to `dist/`.

## Test plan
- [x] Verified `npm run build` outputs to `dist/server/server.js` locally
- [ ] CI Package Admin job should now pass

Made with [Cursor](https://cursor.com)