### PR TITLE
fix(app): fix perushim notes loading + add diagnostics export

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -145,9 +145,18 @@
 		<Exec Command="gunzip -c '$(MSBuildProjectDirectory)/Platforms/Android/AssetPacks/perushim_notes/sefaria-dump-5784-sivan-4.perushim_notes.sqlite.gz' > '$(MSBuildProjectDirectory)/Platforms/iOS/Assets/PerushimNotes.xcassets/perushim_notes.dataset/sefaria-dump-5784-sivan-4.perushim_notes.sqlite'" />
 	</Target>
 
-	<!-- iOS ODR: the PerushimNotes.xcassets catalog (Contents.json + dataset) is auto-globbed
-	     by MAUI's SDK from Platforms/iOS/ — no explicit <ImageAsset Include> needed.
-	     ODR tagging is declared in the dataset's Contents.json (on-demand-resource-tags). -->
+	<!-- iOS ODR: include PerushimNotes.xcassets in the app bundle so ODR is available.
+	     MAUI does not auto-include all Platforms/iOS content; without this, the catalog was missing. -->
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+		<BundleResource Include="Platforms\iOS\Assets\PerushimNotes.xcassets\**\*"
+			TargetPath="PerushimNotes.xcassets\%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<!-- Android Debug fallback: bundle perushim notes in app package so they work without PAD (APK installs). -->
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' AND '$(Configuration)' == 'Debug' AND Exists('Platforms\Android\AssetPacks\perushim_notes\sefaria-dump-5784-sivan-4.perushim_notes.sqlite')">
+		<MauiAsset Include="Platforms\Android\AssetPacks\perushim_notes\sefaria-dump-5784-sivan-4.perushim_notes.sqlite"
+			LogicalName="sefaria-dump-5784-sivan-4.perushim_notes.sqlite" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />

--- a/app/BibleOnSite/Pages/PerekPage.xaml
+++ b/app/BibleOnSite/Pages/PerekPage.xaml
@@ -419,6 +419,12 @@
                                         Text="להוריד פירושים"
                                         IsVisible="{Binding ShowDownloadPerushimButton}"
                                         Clicked="OnDownloadPerushimClicked"/>
+                                <Button Text="ייצוא לוגים לתמיכה"
+                                        Command="{Binding ExportPerushimLogsCommand}"
+                                        AutomationId="ExportPerushimLogsButton"
+                                        IsVisible="{Binding ShowDownloadPerushimButton}"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}"
+                                        TextColor="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
                             </VerticalStackLayout>
                         </CollectionView.EmptyView>
                     </CollectionView>

--- a/app/BibleOnSite/Pages/PreferencesPage.xaml
+++ b/app/BibleOnSite/Pages/PreferencesPage.xaml
@@ -100,6 +100,11 @@
                                 Command="{Binding DownloadPerushimCommand}"
                                 BackgroundColor="{StaticResource Primary}"
                                 TextColor="White"/>
+                        <Button Text="ייצוא לוגים לתמיכה"
+                                Command="{Binding ExportPerushimLogsCommand}"
+                                AutomationId="ExportPerushimLogsButton"
+                                BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}"
+                                TextColor="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>

--- a/app/BibleOnSite/Services/PadDeliveryService.cs
+++ b/app/BibleOnSite/Services/PadDeliveryService.cs
@@ -237,7 +237,7 @@ partial class PadDeliveryService
     /// </summary>
     private static string? SaveOdrAsset(string assetName, string cacheDir)
     {
-        using var dataAsset = new NSDataAsset(assetName);
+        using var dataAsset = new NSDataAsset(assetName, NSBundle.MainBundle);
         if (dataAsset?.Data == null)
             return null;
 

--- a/app/BibleOnSite/ViewModels/PerekViewModel.cs
+++ b/app/BibleOnSite/ViewModels/PerekViewModel.cs
@@ -699,6 +699,31 @@ public partial class PerekViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Exports perushim diagnostics to a file and opens the share sheet for support.
+    /// </summary>
+    [RelayCommand]
+    public async Task ExportPerushimLogsAsync()
+    {
+        try
+        {
+            var report = await PerushimNotesService.Instance.GetDiagnosticsAsync();
+            var fileName = $"perushim_diagnostics_{DateTime.UtcNow:yyyyMMdd_HHmmss}.txt";
+            var path = Path.Combine(FileSystem.CacheDirectory, fileName);
+            await File.WriteAllTextAsync(path, report);
+            await Share.Default.RequestAsync(new ShareFileRequest
+            {
+                Title = "ייצוא לוגים — פירושים",
+                File = new ShareFile(path),
+            });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Export perushim logs failed: {ex.Message}");
+            await Shell.Current.DisplayAlert("שגיאה", $"לא ניתן לייצא לוגים: {ex.Message}", "אישור");
+        }
+    }
+
     #endregion
 #endif
 

--- a/app/BibleOnSite/ViewModels/PreferencesViewModel.cs
+++ b/app/BibleOnSite/ViewModels/PreferencesViewModel.cs
@@ -127,6 +127,32 @@ public partial class PreferencesViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Exports perushim diagnostics to a file and opens the share sheet so the user can save or send for support.
+    /// </summary>
+    [RelayCommand]
+    public async Task ExportPerushimLogsAsync()
+    {
+        try
+        {
+            var report = await _perushimNotesService.GetDiagnosticsAsync();
+            var fileName = $"perushim_diagnostics_{DateTime.UtcNow:yyyyMMdd_HHmmss}.txt";
+            var path = Path.Combine(FileSystem.CacheDirectory, fileName);
+            await File.WriteAllTextAsync(path, report);
+            await Share.Default.RequestAsync(new ShareFileRequest
+            {
+                Title = "ייצוא לוגים — פירושים",
+                File = new ShareFile(path),
+            });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Export perushim logs failed: {ex.Message}");
+            if (Application.Current?.Windows?.Count > 0 && Application.Current.Windows[0].Page is Page page)
+                await page.DisplayAlert("שגיאה", $"לא ניתן לייצא לוגים: {ex.Message}", "אישור");
+        }
+    }
+
+    /// <summary>
     /// Increases font size.
     /// </summary>
     [RelayCommand]


### PR DESCRIPTION
## Summary

- Fix perushim notes not loading on Android (Debug APK) and iOS
- Add app-package fallback when PAD/ODR path is unavailable
- Include PerushimNotes.xcassets explicitly as BundleResource for iOS
- Bundle notes as MauiAsset for Android Debug builds
- Add "Export logs" button when perushim unavailable for diagnostics

## Changes

**PerushimNotesService**: app-package fallback (`FileSystem.OpenAppPackageFileAsync`) + diagnostics report (`GetDiagnosticsAsync`)
**BibleOnSite.csproj**: iOS BundleResource for xcassets, Android Debug MauiAsset fallback
**PadDeliveryService.cs**: use explicit `NSBundle.MainBundle` for `NSDataAsset`
**PerekPage/PreferencesPage**: "Export logs" button when perushim not available
**PerekViewModel/PreferencesViewModel**: `ExportPerushimLogsCommand` via Share sheet

## Test plan

- [x] Unit tests pass (437/437)
- [ ] Verify on Android emulator: perushim load from app package in Debug APK
- [ ] Verify diagnostics export: share sheet opens with `.txt` file

Made with [Cursor](https://cursor.com)