### PR TITLE
fix(app): fix Android AAB packaging (D8 duplicate class + manifest collisions)

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -115,6 +115,9 @@
 		<!-- TODO(#1018): PAD 2.3.0.5 + Plugin.Firebase cause XAAMM0000 manifest collisions on .NET 9;
 		     XAAMM0000 is suppressed in NoWarn. Re-evaluate when migrating to .NET 10. -->
 		<PackageReference Include="Xamarin.Google.Android.Play.Asset.Delivery" Version="2.3.0.5" />
+		<!-- Exclude the JVM variant to prevent D8 "defined multiple times" error (JAVA0000):
+		     both .Android and .Jvm annotation packages contain the same classes. -->
+		<PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />
 	</ItemGroup>
 
 	<!-- Auto-decompress perushim notes .gz → .sqlite if needed (checked out from git as compressed).


### PR DESCRIPTION
## Summary

Follow-up to #1427 and #1428 — Package Android (AAB) was failing on master.

- Exclude `Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm` assets to fix D8 `JAVA0000` duplicate class error (`androidx.compose.runtime.Immutable` defined in both `.Android` and `.Jvm` variants)
- Already includes #1428's fixes: bump Android minSdkVersion 21 → 23, suppress XAAMM0000

## Test plan

- [x] Unit tests pass (437/437)
- [ ] Android AAB packaging succeeds in CI (Package App / Package Android (AAB))

Made with [Cursor](https://cursor.com)