### PR TITLE
fix(app): use D8 --allow-duplicate-classes for AndroidX conflicts

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -110,14 +110,17 @@
 	     Perushim Notes — on-demand delivery (Android PAD + iOS ODR)
 	     ============================================================ -->
 
-	<!-- Android: Play Asset Delivery SDK -->
+	<!-- Android: Play Asset Delivery SDK + D8 duplicate-class workaround.
+	     PAD 2.3.0.5 + Plugin.Firebase pull in AndroidX packages whose .Android/.Jvm/.Ktx
+	     variants contain identical Java classes, causing D8 JAVA0000 "defined multiple times"
+	     errors. allow-duplicate-classes lets D8 pick one copy (they're identical).
+	     XAAMM0000 manifest collisions are suppressed in NoWarn above.
+	     TODO(#1018): re-evaluate both workarounds when migrating to .NET 10. -->
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+		<AndroidD8ExtraArguments>$(AndroidD8ExtraArguments) --allow-duplicate-classes</AndroidD8ExtraArguments>
+	</PropertyGroup>
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-		<!-- TODO(#1018): PAD 2.3.0.5 + Plugin.Firebase cause XAAMM0000 manifest collisions on .NET 9;
-		     XAAMM0000 is suppressed in NoWarn. Re-evaluate when migrating to .NET 10. -->
 		<PackageReference Include="Xamarin.Google.Android.Play.Asset.Delivery" Version="2.3.0.5" />
-		<!-- Exclude the JVM variant to prevent D8 "defined multiple times" error (JAVA0000):
-		     both .Android and .Jvm annotation packages contain the same classes. -->
-		<PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />
 	</ItemGroup>
 
 	<!-- Auto-decompress perushim notes .gz → .sqlite if needed (checked out from git as compressed).


### PR DESCRIPTION
## Summary

Fix Package Android (AAB) failure on master. PAD + Firebase transitively pull in
AndroidX packages whose `.Android`/`.Jvm`/`.Ktx` variants contain identical Java classes,
causing dozens of D8 JAVA0000 "defined multiple times" errors.

`--allow-duplicate-classes` tells D8 to pick one copy (they're identical) instead of failing.

Replaces the individual `ExcludeAssets="all"` workaround from #1429.

## Test plan

- [x] Unit tests pass (437/437)
- [ ] Android AAB packaging succeeds in CI (Package App / Package Android (AAB))

Made with [Cursor](https://cursor.com)