### PR TITLE
fix(app): iOS ODR bundle, bottom bar gap, font size on scroll

### DIFF
--- a/app/BibleOnSite/BibleOnSite.csproj
+++ b/app/BibleOnSite/BibleOnSite.csproj
@@ -47,11 +47,11 @@
 		<ApplicationId>com.tanah.daily929</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>5.0.54</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>5.0.55</ApplicationDisplayVersion>
 		<!-- Windows MSIX requires each version component ≤65535, so we use a separate incrementing value -->
 		<!-- Android versionCode can be large, continuing from Play Store's 40000017 -->
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000054</ApplicationVersion>
-		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">54</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">50000055</ApplicationVersion>
+		<ApplicationVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">55</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<!-- WindowsPackageType None = unpackaged (fixes "Class not registered" when running from CLI). MSIX for Store: /p:WindowsPackageType=MSIX -->

--- a/app/BibleOnSite/Pages/PerekPage.xaml
+++ b/app/BibleOnSite/Pages/PerekPage.xaml
@@ -8,11 +8,13 @@
              xmlns:behaviors="clr-namespace:BibleOnSite.Behaviors"
              xmlns:converters="clr-namespace:BibleOnSite.Converters"
              xmlns:fonts="clr-namespace:Fonts"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
              x:Class="BibleOnSite.Pages.PerekPage"
              x:Name="PerekPageRoot"
              x:DataType="viewmodels:PerekViewModel"
              Title="{Binding Source}"
-             FlowDirection="RightToLeft">
+             FlowDirection="RightToLeft"
+             ios:Page.UseSafeArea="False">
 
     <ContentPage.Resources>
         <ResourceDictionary>
@@ -20,7 +22,7 @@
             <Color x:Key="SelectedPasukBackgroundDark">#1E3A5F</Color>
             <converters:IntEqualityConverter x:Key="IntEqualityConverter"/>
             <converters:PerushCheckedConverter x:Key="PerushCheckedConverter"/>
-            <!-- DataTrigger helper for selection background -->
+            <x:Double x:Key="BottomBarTotalHeight">90</x:Double>
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -187,7 +189,7 @@
                                             Scrolled="OnPasukimScrolled"
                                             Margin="8,0,8,0">
                                 <CollectionView.Footer>
-                                    <ContentView x:Name="PasukimFooterSpacer" HeightRequest="90" BackgroundColor="Transparent"/>
+                                    <ContentView HeightRequest="{DynamicResource BottomBarTotalHeight}" BackgroundColor="Transparent"/>
                                 </CollectionView.Footer>
                                 <CollectionView.ItemTemplate>
                                     <DataTemplate x:DataType="models:Pasuk">
@@ -295,7 +297,7 @@
                             Margin="8,8,8,0">
                 <!-- Footer spacer so last item can scroll above bottom bar -->
                 <CollectionView.Footer>
-                    <ContentView x:Name="ArticlesFooterSpacer" HeightRequest="90" BackgroundColor="Transparent"/>
+                    <ContentView x:Name="ArticlesFooterSpacer" HeightRequest="{DynamicResource BottomBarTotalHeight}" BackgroundColor="Transparent"/>
                 </CollectionView.Footer>
                 <CollectionView.ItemsLayout>
                     <GridItemsLayout Orientation="Vertical"

--- a/app/BibleOnSite/Pages/PerekPage.xaml.cs
+++ b/app/BibleOnSite/Pages/PerekPage.xaml.cs
@@ -37,6 +37,10 @@ public partial class PerekPage : ContentPage
     private static DateTime _lastScrollTime = DateTime.MinValue;
     private const int ScrollCooldownMs = 500; // Don't allow long-press within 500ms of scroll
 
+#if IOS
+    private CancellationTokenSource? _scrollRefreshCts;
+#endif
+
     /// <summary>
     /// Returns true if the user is currently scrolling or just finished scrolling.
     /// Used by LongPressBehavior to prevent false triggers during scroll.
@@ -239,12 +243,31 @@ public partial class PerekPage : ContentPage
     private void OnPasukimScrolled(object? sender, ItemsViewScrolledEventArgs e)
     {
         _lastScrollTime = DateTime.Now;
-        // Cancel any pending long-press (pointer-based for Windows)
         _longPressTokenSource?.Cancel();
         _pressedPasukNum = -1;
-        // Cancel any pending long-press (behavior-based for Android)
         LongPressBehavior.CancelAllPending();
+#if IOS
+        _scrollRefreshCts?.Cancel();
+        _scrollRefreshCts = new CancellationTokenSource();
+        var token = _scrollRefreshCts.Token;
+        _ = DeferredScrollRefreshAsync(token);
+#endif
     }
+
+#if IOS
+    private async Task DeferredScrollRefreshAsync(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(200, token);
+            if (!token.IsCancellationRequested)
+                Dispatcher.Dispatch(() => RefreshDescendantViews(PerekCarousel));
+        }
+        catch (TaskCanceledException)
+        {
+        }
+    }
+#endif
 
     protected override async void OnAppearing()
     {
@@ -349,18 +372,15 @@ public partial class PerekPage : ContentPage
     private void OnPageSizeChanged(object? sender, EventArgs e) => ApplyBottomBarSafeArea();
 
     /// <summary>
-    /// Extends the bottom bar past the safe area to the physical screen edge on iOS.
-    /// The negative margin pushes the bar into the home-indicator region;
-    /// internal bottom padding keeps interactive content above the indicator.
-    /// The floating menu container gets the same treatment so the FAB stays
-    /// aligned with the bar's notch.
+    /// With UseSafeArea="False" the page extends edge-to-edge.
+    /// The bottom bar sits at the physical screen bottom — we only need
+    /// internal padding so interactive content stays above the home indicator.
     /// </summary>
     private void ApplyBottomBarSafeArea()
     {
         var insets = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetSafeAreaInsets(this);
         var bottom = insets.Bottom;
 
-        // Fallback: read native safe area when MAUI reports 0 (layout not ready yet)
         if (bottom <= 0)
         {
             var window = UIKit.UIApplication.SharedApplication?.ConnectedScenes
@@ -373,13 +393,13 @@ public partial class PerekPage : ContentPage
         if (bottom <= 0)
             return;
 
-        BottomBar.Margin = new Thickness(0, 0, 0, -bottom);
+        var totalHeight = 90 + bottom;
         BottomBar.Padding = new Thickness(0, 0, 0, bottom);
-        BottomBar.HeightRequest = 90 + bottom;
+        BottomBar.HeightRequest = totalHeight;
 
-        FloatingMenuContainer.Margin = new Thickness(0, 0, 0, -bottom);
+        FloatingMenuContainer.Padding = new Thickness(0, 0, 0, bottom);
 
-        ArticlesFooterSpacer.HeightRequest = 90 + bottom;
+        Resources["BottomBarTotalHeight"] = totalHeight;
     }
 #endif
 

--- a/app/BibleOnSite/Services/PadDeliveryService.cs
+++ b/app/BibleOnSite/Services/PadDeliveryService.cs
@@ -216,7 +216,7 @@ partial class PadDeliveryService
 
             try
             {
-                return SaveOdrDataAsset(cacheDir);
+                return SaveOdrDataAsset(cacheDir, request.Bundle);
             }
             finally
             {
@@ -253,7 +253,7 @@ partial class PadDeliveryService
             ct.ThrowIfCancellationRequested();
 
             var cacheDir = OdrCacheDir(packName);
-            var result = SaveOdrDataAsset(cacheDir);
+            var result = SaveOdrDataAsset(cacheDir, request.Bundle);
             return result != null;
         }
         catch (OperationCanceledException)
@@ -276,10 +276,11 @@ partial class PadDeliveryService
     /// After BeginAccessingResources, the asset catalog data is available via NSDataAsset.
     /// actool compiles the .dataset into Assets.car, so we read it via NSDataAsset and
     /// write to disk for SQLite file-based access.
+    /// ODR assets live in the request's bundle, not the main bundle.
     /// </summary>
-    private static string? SaveOdrDataAsset(string cacheDir)
+    private static string? SaveOdrDataAsset(string cacheDir, NSBundle bundle)
     {
-        using var asset = new NSDataAsset(DatasetAssetName);
+        using var asset = new NSDataAsset(DatasetAssetName, bundle);
         if (asset?.Data == null)
         {
             System.Diagnostics.Debug.WriteLine($"ODR: NSDataAsset('{DatasetAssetName}') returned null");
@@ -347,8 +348,8 @@ partial class PadDeliveryService
             {
                 try
                 {
-                    using var odrAsset = new NSDataAsset(DatasetAssetName);
-                    lines.Add($"ODR NSDataAsset('{DatasetAssetName}'): {(odrAsset?.Data != null ? $"length={odrAsset.Data.Length}" : "(null)")}");
+                    using var odrAsset = new NSDataAsset(DatasetAssetName, request.Bundle);
+                    lines.Add($"ODR NSDataAsset('{DatasetAssetName}', request.Bundle): {(odrAsset?.Data != null ? $"length={odrAsset.Data.Length}" : "(null)")}");
 
                     if (odrAsset?.Data != null)
                     {
@@ -394,8 +395,8 @@ partial class PadDeliveryService
 
                     try
                     {
-                        using var fetchedAsset = new NSDataAsset(DatasetAssetName);
-                        lines.Add($"Post-fetch NSDataAsset: {(fetchedAsset?.Data != null ? $"length={fetchedAsset.Data.Length}" : "(null)")}");
+                        using var fetchedAsset = new NSDataAsset(DatasetAssetName, fetchReq.Bundle);
+                        lines.Add($"Post-fetch NSDataAsset(request.Bundle): {(fetchedAsset?.Data != null ? $"length={fetchedAsset.Data.Length}" : "(null)")}");
                     }
                     catch (Exception fetchAssetEx)
                     {


### PR DESCRIPTION
## Summary
- **ODR fix**: Pass `request.Bundle` to `NSDataAsset` constructor. The root cause of perushim notes being unavailable on iOS was that `BeginAccessingResources` succeeded but `NSDataAsset(name)` returned nil — ODR assets live in the request's bundle, not the app's main bundle.
- **Bottom bar gap**: Set `ios:Page.UseSafeArea="False"` so the page extends edge-to-edge. Removes the negative-margin workaround that MAUI was clipping at safe area bounds. Bar now naturally sits at the physical screen bottom with internal padding for the home indicator.
- **Font size on scroll**: Added debounced `RefreshDescendantViews` after `CollectionView` scroll on iOS, so newly materialized items pick up `DynamicResource` font sizes when scrolling within the same perek.

## Test plan
- [ ] iOS: Verify perushim notes are available after install from TestFlight
- [ ] iOS: Bottom bar flush with screen edge (no gap above home indicator)
- [ ] iOS: Change font size, scroll up/down within same perek — font size preserved
- [ ] Android/Windows: No regressions in bottom bar or font behavior

Made with [Cursor](https://cursor.com)