### PR TITLE
feat(api): external-AI Tanahpedia entry-revision interface

### DIFF
--- a/data/mysql/tanahpedia_structure.sql
+++ b/data/mysql/tanahpedia_structure.sql
@@ -150,6 +150,28 @@ CREATE TABLE `tanahpedia_entry_entity` (
     CONSTRAINT `fk_entry_entity_entity` FOREIGN KEY (`entity_id`) REFERENCES `tanahpedia_entity` (`id`) ON DELETE CASCADE
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
+-- Entry revisions submitted by EXTERNAL AI clients via the API for human triage.
+-- entry_id NULL = the revision proposes a brand-new entry. status is a free-text
+-- lifecycle marker (PENDING / APPROVED / REJECTED) kept as a string to avoid an
+-- enum migration; nothing is applied to `tanahpedia_entry` until a human approves.
+DROP TABLE IF EXISTS `tanahpedia_entry_revision`;
+CREATE TABLE `tanahpedia_entry_revision` (
+    `id` char(36) NOT NULL,
+    `entry_id` char(36) DEFAULT NULL COMMENT 'NULL = proposes a new entry',
+    `proposed_unique_name` varchar(255) DEFAULT NULL,
+    `proposed_title` varchar(255) DEFAULT NULL,
+    `proposed_content` mediumtext,
+    `source` varchar(255) NOT NULL COMMENT 'External AI client / model identifier',
+    `notes` text COMMENT 'AI rationale / notes for the human editor',
+    `status` varchar(20) NOT NULL DEFAULT 'PENDING',
+    `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `idx_entry_revision_entry` (`entry_id`),
+    KEY `idx_entry_revision_status` (`status`),
+    CONSTRAINT `fk_entry_revision_entry` FOREIGN KEY (`entry_id`) REFERENCES `tanahpedia_entry` (`id`) ON DELETE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
 -- -------------------------------------------
 -- PERSON
 -- -------------------------------------------

--- a/docs/tanahpedia/README.md
+++ b/docs/tanahpedia/README.md
@@ -5,6 +5,7 @@ Encyclopedic layer for the Bible-on-site stack: entries, entities (person, place
 ## Contents
 
 - **[implementation-plan.md](./implementation-plan.md)** – Implementation plan (data layer, website, app, API, admin, future plans).
+- **[external-revision-api.md](./external-revision-api.md)** – API-first external-AI revision interface (`submitEntryRevision` mutation, triage query, auth).
 - **[tanachpedia.dbml](./tanachpedia.dbml)** – Canonical DBML schema for all `tanahpedia_*` tables.
 
 ## GitHub project and issues

--- a/docs/tanahpedia/external-revision-api.md
+++ b/docs/tanahpedia/external-revision-api.md
@@ -1,0 +1,75 @@
+# Tanahpedia External Revision API
+
+API-first interface that lets an **external AI client** propose revisions to Tanahpedia
+entries. Proposals are stored as `PENDING` rows in `tanahpedia_entry_revision` for human
+triage in the Admin GUI and are **never auto-applied** to the live entry.
+
+## Endpoint
+
+- **GraphQL:** `POST /` on the Bible-on-site API.
+- **Auth:** every mutation requires
+  `Authorization: Bearer <TANAHPEDIA_REVISION_API_KEY>`.
+  The endpoint **fails closed** — if `TANAHPEDIA_REVISION_API_KEY` is unset/empty on the
+  server, or the bearer token does not match (constant-time compare), the request is
+  rejected with `UNAUTHORIZED`.
+
+## Mutation — submit a revision
+
+```graphql
+mutation Submit($input: SubmitEntryRevisionInput!) {
+  submitEntryRevision(input: $input) {
+    id
+    status      # always "PENDING" on creation
+    createdAt
+  }
+}
+```
+
+`SubmitEntryRevisionInput`:
+
+| Field                | Type     | Notes                                                                  |
+| -------------------- | -------- | ---------------------------------------------------------------------- |
+| `entryId`            | `String` | Existing entry to revise. **Omit** to propose a brand-new entry.       |
+| `proposedUniqueName` | `String` | Proposed `unique_name`.                                                |
+| `proposedTitle`      | `String` | Proposed title.                                                        |
+| `proposedContent`    | `String` | Proposed entry body (HTML).                                            |
+| `source`             | `String!`| **Required.** External AI client / model id (e.g. `"gpt-4o"`).         |
+| `notes`              | `String` | AI rationale / notes for the human editor.                             |
+
+Validation (server-side):
+
+- `source` must be non-blank.
+- At least one of `proposedUniqueName` / `proposedTitle` / `proposedContent` must be present.
+- When `entryId` is supplied it must reference an existing entry, otherwise `NOT_FOUND`.
+
+## Query — triage queue (Admin / internal)
+
+```graphql
+query Pending {
+  tanahpediaEntryRevisions(status: "PENDING") {
+    id
+    entryId
+    proposedTitle
+    source
+    notes
+    createdAt
+  }
+}
+```
+
+Both `status` (`PENDING` / `APPROVED` / `REJECTED`) and `entryId` are optional filters;
+results are returned newest-first.
+
+## Storage
+
+Table `tanahpedia_entry_revision` (see [tanachpedia.dbml](./tanachpedia.dbml)) — a staging
+area decoupled from `tanahpedia_entry`. `entry_id` is nullable (new-entry proposals) with
+`ON DELETE CASCADE`, and `status` defaults to `PENDING`.
+
+## Server environment
+
+| Variable                     | Description                                                        |
+| ---------------------------- | ----------------------------------------------------------------- |
+| `TANAHPEDIA_REVISION_API_KEY`| Bearer token external AI clients must present. Endpoint fails closed when unset. |
+
+Set it in the API environment (`.env` / ECS task definition). Never expose it client-side.

--- a/docs/tanahpedia/external-revision-api.md
+++ b/docs/tanahpedia/external-revision-api.md
@@ -1,8 +1,11 @@
 # Tanahpedia External Revision API
 
-API-first interface that lets an **external AI client** propose revisions to Tanahpedia
-entries. Proposals are stored as `PENDING` rows in `tanahpedia_entry_revision` for human
-triage in the Admin GUI and are **never auto-applied** to the live entry.
+API-first interface that lets an **external AI client** propose — and, when authorized,
+apply — revisions to Tanahpedia entries. Submissions are stored as `PENDING` rows in
+`tanahpedia_entry_revision` and are never applied as a side effect of submission. The same
+authorized client (or a human in the Admin GUI) then applies a revision **explicitly**,
+which updates the live `tanahpedia_entry` and marks the revision `APPLIED`. The revision
+row is retained as the change's audit/history record.
 
 ## Endpoint
 
@@ -42,6 +45,30 @@ Validation (server-side):
 - At least one of `proposedUniqueName` / `proposedTitle` / `proposedContent` must be present.
 - When `entryId` is supplied it must reference an existing entry, otherwise `NOT_FOUND`.
 
+## Mutation — apply a revision
+
+Applies a stored revision to the live entry. **Authorized only** (same bearer token as
+submission — the whole API is for authorized clients, not the public).
+
+```graphql
+mutation Apply($id: String!) {
+  applyEntryRevision(id: $id) {
+    id
+    entryId     # the live entry the change was applied to
+    status      # "APPLIED"
+    updatedAt
+  }
+}
+```
+
+- **Existing entry:** the revision's present `proposed*` fields overwrite that entry; absent
+  fields are left untouched.
+- **New entry** (`entryId` was null): a new entry is created — this requires both
+  `proposedUniqueName` and `proposedTitle` (the entry's non-null columns) — and the revision
+  is linked back to the new entry.
+- Re-applying an already-`APPLIED` revision is rejected (`BAD_REQUEST`); a missing revision
+  or a deleted target entry returns `NOT_FOUND`.
+
 ## Query — triage queue (Admin / internal)
 
 ```graphql
@@ -57,7 +84,7 @@ query Pending {
 }
 ```
 
-Both `status` (`PENDING` / `APPROVED` / `REJECTED`) and `entryId` are optional filters;
+Both `status` (`PENDING` / `APPLIED` / `APPROVED` / `REJECTED`) and `entryId` are optional filters;
 results are returned newest-first.
 
 ## Storage

--- a/docs/tanahpedia/tanachpedia.dbml
+++ b/docs/tanahpedia/tanachpedia.dbml
@@ -207,6 +207,22 @@ Table tanahpedia_entry_entity {
   entity_id char(36) [ref: > tanahpedia_entity.id]
 }
 
+// Revisions fed by EXTERNAL AI clients through the API for human triage.
+// entry_id NULL => proposes a brand-new entry. Nothing is applied to
+// tanahpedia_entry until a human approves the revision.
+Table tanahpedia_entry_revision {
+  id char(36) [pk]
+  entry_id char(36) [ref: > tanahpedia_entry.id, note: 'NULL = proposes a new entry']
+  proposed_unique_name varchar(255)
+  proposed_title varchar(255)
+  proposed_content mediumtext
+  source varchar(255) [note: 'External AI client / model identifier']
+  notes text [note: 'AI rationale / notes for the human editor']
+  status varchar(20) [note: 'PENDING, APPROVED, REJECTED']
+  created_at datetime
+  updated_at datetime
+}
+
 // -------------------------------------------
 // PERSON
 // -------------------------------------------

--- a/web/api/Cargo.lock
+++ b/web/api/Cargo.lock
@@ -592,7 +592,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bible-on-site-api"
-version = "0.1.25"
+version = "0.1.33"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -600,6 +600,7 @@ dependencies = [
  "async-graphql-actix-web",
  "cargo-llvm-cov",
  "cargo-make",
+ "chrono",
  "derive_more",
  "dotenvy",
  "entities",
@@ -613,6 +614,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-log 0.2.0",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/web/api/Cargo.toml
+++ b/web/api/Cargo.toml
@@ -5,7 +5,7 @@ description = "Bible on Site API"
 license-file = "../../license"
 repository = "https://github.com/bible-on-site/bible-on-site"
 publish = false
-version = "0.1.25"
+version = "0.1.33"
 edition = "2024"
 
 [dependencies]
@@ -34,6 +34,8 @@ sea-orm = { version = "1.1.19", default-features = false, features = [
     "runtime-actix-native-tls",
 ] }
 entities = { path = "./entities" }
+uuid = { version = "1.18.1", features = ["v4"] }
+chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 cargo-llvm-cov = "0.8.0"

--- a/web/api/entities/src/tanahpedia/entry_revision.rs
+++ b/web/api/entities/src/tanahpedia/entry_revision.rs
@@ -1,0 +1,39 @@
+use sea_orm::entity::prelude::*;
+
+/// A revision to a Tanahpedia entry fed by an external AI client through the API.
+///
+/// `entry_id` is `None` when the revision proposes a brand-new entry. Revisions
+/// are never auto-applied to `tanahpedia_entry`; a human triages them via the
+/// admin panel. `status` is a free-text lifecycle marker (`PENDING`, `APPROVED`,
+/// `REJECTED`).
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "tanahpedia_entry_revision")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub entry_id: Option<String>,
+    pub proposed_unique_name: Option<String>,
+    pub proposed_title: Option<String>,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub proposed_content: Option<String>,
+    pub source: String,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub notes: Option<String>,
+    pub status: String,
+    pub created_at: DateTime,
+    pub updated_at: DateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C: ConnectionTrait>(
+        mut self,
+        _: &C,
+        _insert: bool,
+    ) -> Result<Self, DbErr> {
+        Ok(self)
+    }
+}

--- a/web/api/entities/src/tanahpedia/mod.rs
+++ b/web/api/entities/src/tanahpedia/mod.rs
@@ -4,6 +4,7 @@ pub mod astronomical_object_creation_day;
 pub mod category_homepage;
 pub mod entry;
 pub mod entry_entity;
+pub mod entry_revision;
 pub mod entry_synonym;
 pub mod entry_synonym_disambiguation;
 pub mod event;

--- a/web/api/src/common/auth.rs
+++ b/web/api/src/common/auth.rs
@@ -1,0 +1,107 @@
+use std::env;
+
+use crate::common::error_handling::ServiceError;
+
+/// Name of the environment variable holding the shared secret that external AI
+/// clients must present (as a `Authorization: Bearer <key>` header) to submit
+/// Tanahpedia entry revisions.
+pub const REVISION_API_KEY_ENV: &str = "TANAHPEDIA_REVISION_API_KEY";
+
+/// Bearer token extracted from the incoming HTTP request and injected into the
+/// GraphQL context. `None` means no usable `Authorization: Bearer` header was
+/// present on the request.
+#[derive(Clone, Debug, Default)]
+pub struct ApiAuth {
+    bearer: Option<String>,
+}
+
+impl ApiAuth {
+    pub fn new(bearer: Option<String>) -> Self {
+        Self { bearer }
+    }
+
+    /// Authorizes a request to submit an entry revision.
+    ///
+    /// Fails closed: if `TANAHPEDIA_REVISION_API_KEY` is unset/empty the endpoint
+    /// is disabled and every request is rejected. The presented token is compared
+    /// to the configured key in constant time to avoid leaking it via timing.
+    pub fn authorize_revision_submitter(&self) -> Result<(), ServiceError> {
+        let expected = env::var(REVISION_API_KEY_ENV)
+            .ok()
+            .filter(|key| !key.is_empty());
+
+        match (expected, self.bearer.as_deref()) {
+            (Some(expected), Some(presented)) if constant_time_eq(&expected, presented) => Ok(()),
+            (None, _) => Err(ServiceError::unauthorized(
+                "Revision submission is not configured",
+            )),
+            _ => Err(ServiceError::unauthorized("Invalid or missing API key")),
+        }
+    }
+}
+
+/// Constant-time string comparison. Returns `false` immediately on length
+/// mismatch (length is not secret here) and otherwise ORs the XOR of every byte
+/// so the running time does not depend on where the first difference is.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serialize tests that mutate the shared process env var.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn constant_time_eq_matches_std_equality() {
+        assert!(constant_time_eq("secret-key", "secret-key"));
+        assert!(!constant_time_eq("secret-key", "secret-keyy"));
+        assert!(!constant_time_eq("secret-key", "wrong-key0"));
+        assert!(!constant_time_eq("", "x"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    #[test]
+    fn authorize_fails_when_key_not_configured() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { env::remove_var(REVISION_API_KEY_ENV) };
+        let auth = ApiAuth::new(Some("anything".to_string()));
+        assert!(auth.authorize_revision_submitter().is_err());
+    }
+
+    #[test]
+    fn authorize_fails_with_wrong_or_missing_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { env::set_var(REVISION_API_KEY_ENV, "correct-horse") };
+        assert!(
+            ApiAuth::new(Some("wrong".to_string()))
+                .authorize_revision_submitter()
+                .is_err()
+        );
+        assert!(ApiAuth::new(None).authorize_revision_submitter().is_err());
+        unsafe { env::remove_var(REVISION_API_KEY_ENV) };
+    }
+
+    #[test]
+    fn authorize_succeeds_with_correct_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { env::set_var(REVISION_API_KEY_ENV, "correct-horse") };
+        assert!(
+            ApiAuth::new(Some("correct-horse".to_string()))
+                .authorize_revision_submitter()
+                .is_ok()
+        );
+        unsafe { env::remove_var(REVISION_API_KEY_ENV) };
+    }
+}

--- a/web/api/src/common/auth.rs
+++ b/web/api/src/common/auth.rs
@@ -20,21 +20,19 @@ impl ApiAuth {
         Self { bearer }
     }
 
-    /// Authorizes a request to submit an entry revision.
+    /// Authorizes a request to submit or apply an entry revision.
     ///
     /// Fails closed: if `TANAHPEDIA_REVISION_API_KEY` is unset/empty the endpoint
     /// is disabled and every request is rejected. The presented token is compared
     /// to the configured key in constant time to avoid leaking it via timing.
-    pub fn authorize_revision_submitter(&self) -> Result<(), ServiceError> {
+    pub fn authorize_revision_manager(&self) -> Result<(), ServiceError> {
         let expected = env::var(REVISION_API_KEY_ENV)
             .ok()
             .filter(|key| !key.is_empty());
 
         match (expected, self.bearer.as_deref()) {
             (Some(expected), Some(presented)) if constant_time_eq(&expected, presented) => Ok(()),
-            (None, _) => Err(ServiceError::unauthorized(
-                "Revision submission is not configured",
-            )),
+            (None, _) => Err(ServiceError::unauthorized("Revision API is not configured")),
             _ => Err(ServiceError::unauthorized("Invalid or missing API key")),
         }
     }
@@ -77,7 +75,7 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         unsafe { env::remove_var(REVISION_API_KEY_ENV) };
         let auth = ApiAuth::new(Some("anything".to_string()));
-        assert!(auth.authorize_revision_submitter().is_err());
+        assert!(auth.authorize_revision_manager().is_err());
     }
 
     #[test]
@@ -86,10 +84,10 @@ mod tests {
         unsafe { env::set_var(REVISION_API_KEY_ENV, "correct-horse") };
         assert!(
             ApiAuth::new(Some("wrong".to_string()))
-                .authorize_revision_submitter()
+                .authorize_revision_manager()
                 .is_err()
         );
-        assert!(ApiAuth::new(None).authorize_revision_submitter().is_err());
+        assert!(ApiAuth::new(None).authorize_revision_manager().is_err());
         unsafe { env::remove_var(REVISION_API_KEY_ENV) };
     }
 
@@ -99,7 +97,7 @@ mod tests {
         unsafe { env::set_var(REVISION_API_KEY_ENV, "correct-horse") };
         assert!(
             ApiAuth::new(Some("correct-horse".to_string()))
-                .authorize_revision_submitter()
+                .authorize_revision_manager()
                 .is_ok()
         );
         unsafe { env::remove_var(REVISION_API_KEY_ENV) };

--- a/web/api/src/common/error_handling.rs
+++ b/web/api/src/common/error_handling.rs
@@ -7,12 +7,20 @@ pub enum ServiceError {
     InternalServerError(String),
     #[display("{_0}")]
     NotFound(String),
+    #[display("{_0}")]
+    BadRequest(String),
+    #[display("{_0}")]
+    Unauthorized(String),
 }
 
 pub const INTERNAL_SERVER_ERROR: &str = "Internal Server Error";
 pub const INTERNAL_SERVER_ERROR_STATUS_CODE: u16 = 500;
 pub const NOT_FOUND: &str = "Not Found";
 pub const NOT_FOUND_STATUS_CODE: u16 = 404;
+pub const BAD_REQUEST: &str = "Bad Request";
+pub const BAD_REQUEST_STATUS_CODE: u16 = 400;
+pub const UNAUTHORIZED: &str = "Unauthorized";
+pub const UNAUTHORIZED_STATUS_CODE: u16 = 401;
 
 impl ErrorExtensions for ServiceError {
     fn extend(&self) -> Error {
@@ -24,6 +32,14 @@ impl ErrorExtensions for ServiceError {
             ServiceError::NotFound(_) => {
                 e.set("code", "NOT_FOUND");
                 e.set("statusCode", NOT_FOUND_STATUS_CODE);
+            }
+            ServiceError::BadRequest(_) => {
+                e.set("code", "BAD_REQUEST");
+                e.set("statusCode", BAD_REQUEST_STATUS_CODE);
+            }
+            ServiceError::Unauthorized(_) => {
+                e.set("code", "UNAUTHORIZED");
+                e.set("statusCode", UNAUTHORIZED_STATUS_CODE);
             }
         })
     }
@@ -58,5 +74,15 @@ impl ServiceError {
         }
 
         error
+    }
+
+    pub fn bad_request(message: &str) -> Self {
+        tracing::warn!(BAD_REQUEST, %message);
+        Self::BadRequest(message.to_string())
+    }
+
+    pub fn unauthorized(message: &str) -> Self {
+        tracing::warn!(UNAUTHORIZED, %message);
+        Self::Unauthorized(message.to_string())
     }
 }

--- a/web/api/src/common/mod.rs
+++ b/web/api/src/common/mod.rs
@@ -1,1 +1,2 @@
+pub mod auth;
 pub mod error_handling;

--- a/web/api/src/dtos/mod.rs
+++ b/web/api/src/dtos/mod.rs
@@ -3,3 +3,4 @@ pub mod author;
 pub mod perek;
 pub mod sefer;
 pub mod starter;
+pub mod tanahpedia_entry_revision;

--- a/web/api/src/dtos/tanahpedia_entry_revision.rs
+++ b/web/api/src/dtos/tanahpedia_entry_revision.rs
@@ -16,7 +16,7 @@ pub struct EntryRevision {
     pub source: String,
     /// AI rationale / notes for the human editor.
     pub notes: Option<String>,
-    /// Lifecycle marker: `PENDING`, `APPROVED`, or `REJECTED`.
+    /// Lifecycle marker: `PENDING`, `APPLIED`, `APPROVED`, or `REJECTED`.
     pub status: String,
     pub created_at: String,
     pub updated_at: String,

--- a/web/api/src/dtos/tanahpedia_entry_revision.rs
+++ b/web/api/src/dtos/tanahpedia_entry_revision.rs
@@ -1,0 +1,53 @@
+use async_graphql::{InputObject, SimpleObject};
+
+use entities::tanahpedia::entry_revision::Model;
+
+/// A Tanahpedia entry revision proposed by an external AI client.
+#[derive(SimpleObject, Debug, Clone)]
+pub struct EntryRevision {
+    pub id: String,
+    /// `None` when the revision proposes a brand-new entry.
+    pub entry_id: Option<String>,
+    pub proposed_unique_name: Option<String>,
+    pub proposed_title: Option<String>,
+    /// Proposed entry body (HTML), as produced by the external AI.
+    pub proposed_content: Option<String>,
+    /// External AI client / model identifier (e.g. `"gpt-4o"`).
+    pub source: String,
+    /// AI rationale / notes for the human editor.
+    pub notes: Option<String>,
+    /// Lifecycle marker: `PENDING`, `APPROVED`, or `REJECTED`.
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<Model> for EntryRevision {
+    fn from(value: Model) -> Self {
+        Self {
+            id: value.id,
+            entry_id: value.entry_id,
+            proposed_unique_name: value.proposed_unique_name,
+            proposed_title: value.proposed_title,
+            proposed_content: value.proposed_content,
+            source: value.source,
+            notes: value.notes,
+            status: value.status,
+            created_at: value.created_at.to_string(),
+            updated_at: value.updated_at.to_string(),
+        }
+    }
+}
+
+/// Input for `submitEntryRevision`. At least one of the `proposed_*` fields must
+/// be present, and `source` must be non-empty. When `entry_id` is provided it
+/// must reference an existing entry; omit it to propose a brand-new entry.
+#[derive(InputObject, Debug, Clone, Default)]
+pub struct SubmitEntryRevisionInput {
+    pub entry_id: Option<String>,
+    pub proposed_unique_name: Option<String>,
+    pub proposed_title: Option<String>,
+    pub proposed_content: Option<String>,
+    pub source: String,
+    pub notes: Option<String>,
+}

--- a/web/api/src/resolvers/mod.rs
+++ b/web/api/src/resolvers/mod.rs
@@ -3,3 +3,4 @@ pub mod authors_resolver;
 pub mod perakim_resolver;
 pub mod sefarim_resolver;
 pub mod starter_resolver;
+pub mod tanahpedia_revisions_resolver;

--- a/web/api/src/resolvers/tanahpedia_revisions_resolver.rs
+++ b/web/api/src/resolvers/tanahpedia_revisions_resolver.rs
@@ -46,11 +46,30 @@ impl TanahpediaRevisionsMutation {
         input: SubmitEntryRevisionInput,
     ) -> Result<EntryRevision> {
         ctx.data::<ApiAuth>()?
-            .authorize_revision_submitter()
+            .authorize_revision_manager()
             .map_err(|e| e.extend())?;
 
         Ok(
             tanahpedia_revisions_service::create_revision(ctx.data::<Database>()?, input)
+                .await
+                .map_err(|e| e.extend())?
+                .into(),
+        )
+    }
+
+    /// Apply a stored revision to the live entry (authorized clients only).
+    ///
+    /// Requires the same `Authorization: Bearer <TANAHPEDIA_REVISION_API_KEY>`
+    /// header as submission. The revision row is retained as the change's audit
+    /// record and marked `APPLIED`. When the revision has no `entryId` a new
+    /// entry is created and linked back to the revision.
+    async fn apply_entry_revision(&self, ctx: &Context<'_>, id: String) -> Result<EntryRevision> {
+        ctx.data::<ApiAuth>()?
+            .authorize_revision_manager()
+            .map_err(|e| e.extend())?;
+
+        Ok(
+            tanahpedia_revisions_service::apply_revision(ctx.data::<Database>()?, id)
                 .await
                 .map_err(|e| e.extend())?
                 .into(),

--- a/web/api/src/resolvers/tanahpedia_revisions_resolver.rs
+++ b/web/api/src/resolvers/tanahpedia_revisions_resolver.rs
@@ -1,0 +1,59 @@
+use async_graphql::{Context, ErrorExtensions, Object, Result};
+
+use crate::common::auth::ApiAuth;
+use crate::dtos::tanahpedia_entry_revision::{EntryRevision, SubmitEntryRevisionInput};
+use crate::providers::Database;
+use crate::services::tanahpedia_revisions_service;
+
+#[derive(Default)]
+pub struct TanahpediaRevisionsQuery;
+
+#[Object]
+impl TanahpediaRevisionsQuery {
+    /// List Tanahpedia entry revisions (newest first) for human triage,
+    /// optionally filtered by `status` (PENDING / APPROVED / REJECTED) and/or the
+    /// targeted `entryId`.
+    async fn tanahpedia_entry_revisions(
+        &self,
+        ctx: &Context<'_>,
+        status: Option<String>,
+        entry_id: Option<String>,
+    ) -> Result<Vec<EntryRevision>> {
+        Ok(
+            tanahpedia_revisions_service::find_revisions(ctx.data::<Database>()?, status, entry_id)
+                .await
+                .map_err(|e| e.extend())?
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct TanahpediaRevisionsMutation;
+
+#[Object]
+impl TanahpediaRevisionsMutation {
+    /// Submit a revision to a Tanahpedia entry from an external AI client.
+    ///
+    /// Requires an `Authorization: Bearer <TANAHPEDIA_REVISION_API_KEY>` header.
+    /// The revision is stored with status `PENDING` for human triage and is never
+    /// auto-applied to the live entry.
+    async fn submit_entry_revision(
+        &self,
+        ctx: &Context<'_>,
+        input: SubmitEntryRevisionInput,
+    ) -> Result<EntryRevision> {
+        ctx.data::<ApiAuth>()?
+            .authorize_revision_submitter()
+            .map_err(|e| e.extend())?;
+
+        Ok(
+            tanahpedia_revisions_service::create_revision(ctx.data::<Database>()?, input)
+                .await
+                .map_err(|e| e.extend())?
+                .into(),
+        )
+    }
+}

--- a/web/api/src/services/mod.rs
+++ b/web/api/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod articles_service;
 pub mod authors_service;
 pub mod perakim_service;
 pub mod sefarim_service;
+pub mod tanahpedia_revisions_service;

--- a/web/api/src/services/tanahpedia_revisions_service.rs
+++ b/web/api/src/services/tanahpedia_revisions_service.rs
@@ -1,0 +1,286 @@
+use crate::{
+    common::error_handling::{INTERNAL_SERVER_ERROR, ServiceError},
+    dtos::tanahpedia_entry_revision::SubmitEntryRevisionInput,
+    providers::Database,
+};
+use entities::tanahpedia::{entry, entry_revision};
+use sea_orm::{ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder};
+
+const REVISION_STATUS_PENDING: &str = "PENDING";
+
+/// Normalizes an optional, possibly-blank string into `Some(trimmed)` or `None`.
+fn normalize(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Persists a revision proposed by an external AI client for human triage.
+///
+/// Validation:
+/// - `source` is required (non-blank).
+/// - at least one of `proposed_unique_name` / `proposed_title` /
+///   `proposed_content` must be present.
+/// - when `entry_id` is supplied it must reference an existing entry; omit it to
+///   propose a brand-new entry.
+///
+/// The revision is always stored with status `PENDING`; nothing is applied to
+/// `tanahpedia_entry` here — a human reviews it later.
+pub async fn create_revision(
+    db: &Database,
+    input: SubmitEntryRevisionInput,
+) -> Result<entry_revision::Model, ServiceError> {
+    tracing::info_span!("tanahpedia_revisions_service::create_revision");
+
+    let source = normalize(Some(input.source))
+        .ok_or_else(|| ServiceError::bad_request("source is required"))?;
+    let proposed_unique_name = normalize(input.proposed_unique_name);
+    let proposed_title = normalize(input.proposed_title);
+    let proposed_content = normalize(input.proposed_content);
+    let notes = normalize(input.notes);
+    let entry_id = normalize(input.entry_id);
+
+    if proposed_unique_name.is_none() && proposed_title.is_none() && proposed_content.is_none() {
+        return Err(ServiceError::bad_request(
+            "at least one of proposedUniqueName, proposedTitle or proposedContent is required",
+        ));
+    }
+
+    // When targeting an existing entry, it must exist.
+    if let Some(ref id) = entry_id {
+        let existing = entry::Entity::find_by_id(id.clone())
+            .one(db.get_connection())
+            .await
+            .map_err(|db_err| {
+                ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+            })?;
+        if existing.is_none() {
+            return Err(ServiceError::bad_request(
+                "entryId does not reference an existing entry",
+            ));
+        }
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+    let model = entry_revision::Model {
+        id: uuid::Uuid::new_v4().to_string(),
+        entry_id,
+        proposed_unique_name,
+        proposed_title,
+        proposed_content,
+        source,
+        notes,
+        status: REVISION_STATUS_PENDING.to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+
+    entry_revision::Entity::insert(model.clone().into_active_model())
+        .exec(db.get_connection())
+        .await
+        .map_err(|db_err| {
+            ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+        })?;
+
+    tracing::info!(revision_id = %model.id, source = %model.source, "Stored entry revision");
+    Ok(model)
+}
+
+/// Lists entry revisions, newest first, optionally filtered by status and/or the
+/// targeted entry. Intended for the admin triage view.
+pub async fn find_revisions(
+    db: &Database,
+    status: Option<String>,
+    entry_id: Option<String>,
+) -> Result<Vec<entry_revision::Model>, ServiceError> {
+    tracing::info_span!("tanahpedia_revisions_service::find_revisions");
+
+    let mut query = entry_revision::Entity::find();
+    if let Some(status) = normalize(status) {
+        query = query.filter(entry_revision::Column::Status.eq(status));
+    }
+    if let Some(entry_id) = normalize(entry_id) {
+        query = query.filter(entry_revision::Column::EntryId.eq(entry_id));
+    }
+
+    let revisions = query
+        .order_by_desc(entry_revision::Column::CreatedAt)
+        .all(db.get_connection())
+        .await
+        .map_err(|db_err| {
+            ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+        })?;
+
+    tracing::info!("Found {} entry revisions", revisions.len());
+    Ok(revisions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    fn input_with_title(title: &str) -> SubmitEntryRevisionInput {
+        SubmitEntryRevisionInput {
+            source: "gpt-4o".to_string(),
+            proposed_title: Some(title.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn entry_model(id: &str) -> entry::Model {
+        entry::Model {
+            id: id.to_string(),
+            unique_name: "avraham".to_string(),
+            title: "אברהם".to_string(),
+            content: None,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_revision_rejects_blank_source() {
+        let db =
+            Database::from_connection(MockDatabase::new(DatabaseBackend::MySql).into_connection());
+        let input = SubmitEntryRevisionInput {
+            source: "   ".to_string(),
+            proposed_title: Some("x".to_string()),
+            ..Default::default()
+        };
+
+        let err = create_revision(&db, input).await.unwrap_err();
+        assert!(matches!(err, ServiceError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn create_revision_rejects_when_no_proposed_fields() {
+        let db =
+            Database::from_connection(MockDatabase::new(DatabaseBackend::MySql).into_connection());
+        let input = SubmitEntryRevisionInput {
+            source: "gpt-4o".to_string(),
+            proposed_title: Some("  ".to_string()),
+            ..Default::default()
+        };
+
+        let err = create_revision(&db, input).await.unwrap_err();
+        assert!(matches!(err, ServiceError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn create_revision_rejects_unknown_entry_id() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry::Model, Vec<entry::Model>, _>([vec![]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+        let input = SubmitEntryRevisionInput {
+            source: "gpt-4o".to_string(),
+            entry_id: Some("does-not-exist".to_string()),
+            proposed_title: Some("x".to_string()),
+            ..Default::default()
+        };
+
+        let err = create_revision(&db, input).await.unwrap_err();
+        assert!(matches!(err, ServiceError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn create_revision_stores_new_entry_proposal() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let revision = create_revision(&db, input_with_title("ערך חדש"))
+            .await
+            .expect("revision should be created");
+
+        assert_eq!(revision.source, "gpt-4o");
+        assert_eq!(revision.status, "PENDING");
+        assert_eq!(revision.proposed_title.as_deref(), Some("ערך חדש"));
+        assert!(revision.entry_id.is_none());
+        assert!(!revision.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_revision_stores_revision_for_existing_entry() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry::Model, Vec<entry::Model>, _>([vec![entry_model(
+                "entry-1",
+            )]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+        let input = SubmitEntryRevisionInput {
+            source: "claude".to_string(),
+            entry_id: Some("entry-1".to_string()),
+            proposed_content: Some("<p>טקסט</p>".to_string()),
+            ..Default::default()
+        };
+
+        let revision = create_revision(&db, input)
+            .await
+            .expect("revision should be created");
+
+        assert_eq!(revision.entry_id.as_deref(), Some("entry-1"));
+        assert_eq!(revision.proposed_content.as_deref(), Some("<p>טקסט</p>"));
+    }
+
+    #[tokio::test]
+    async fn create_revision_surfaces_db_errors() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_exec_errors([sea_orm::DbErr::Custom("insert failed".to_string())])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = create_revision(&db, input_with_title("x"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::InternalServerError(_)));
+    }
+
+    #[tokio::test]
+    async fn find_revisions_returns_rows() {
+        let row = entry_revision::Model {
+            id: "rev-1".to_string(),
+            entry_id: None,
+            proposed_unique_name: None,
+            proposed_title: Some("t".to_string()),
+            proposed_content: None,
+            source: "gpt-4o".to_string(),
+            notes: None,
+            status: "PENDING".to_string(),
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+        };
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                row,
+            ]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let revisions = find_revisions(&db, Some("PENDING".to_string()), None)
+            .await
+            .expect("should query");
+        assert_eq!(revisions.len(), 1);
+        assert_eq!(revisions[0].id, "rev-1");
+    }
+
+    #[tokio::test]
+    async fn find_revisions_surfaces_db_errors() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_errors([sea_orm::DbErr::Custom("boom".to_string())])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = find_revisions(&db, None, None).await.unwrap_err();
+        assert!(matches!(err, ServiceError::InternalServerError(_)));
+    }
+}

--- a/web/api/src/services/tanahpedia_revisions_service.rs
+++ b/web/api/src/services/tanahpedia_revisions_service.rs
@@ -4,9 +4,11 @@ use crate::{
     providers::Database,
 };
 use entities::tanahpedia::{entry, entry_revision};
+use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder};
 
 const REVISION_STATUS_PENDING: &str = "PENDING";
+const REVISION_STATUS_APPLIED: &str = "APPLIED";
 
 /// Normalizes an optional, possibly-blank string into `Some(trimmed)` or `None`.
 fn normalize(value: Option<String>) -> Option<String> {
@@ -113,6 +115,129 @@ pub async fn find_revisions(
 
     tracing::info!("Found {} entry revisions", revisions.len());
     Ok(revisions)
+}
+
+/// Applies a stored revision to the live `tanahpedia_entry`, then marks the
+/// revision `APPLIED`. Gated by the same API key that authorizes submission, so
+/// an authorized client can apply directly; the revision row is retained as the
+/// audit/history record for the change.
+///
+/// - When the revision targets an existing entry, its present `proposed_*`
+///   fields overwrite that entry (absent fields are left untouched).
+/// - When the revision has no `entry_id`, a brand-new entry is created — this
+///   requires both `proposed_unique_name` and `proposed_title` (the entry's
+///   non-null columns) — and the revision is linked to the new entry.
+///
+/// Re-applying an already-`APPLIED` revision is rejected.
+pub async fn apply_revision(
+    db: &Database,
+    revision_id: String,
+) -> Result<entry_revision::Model, ServiceError> {
+    tracing::info_span!("tanahpedia_revisions_service::apply_revision");
+
+    let conn = db.get_connection();
+
+    let revision = entry_revision::Entity::find_by_id(revision_id.clone())
+        .one(conn)
+        .await
+        .map_err(|db_err| ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err)))?
+        .ok_or_else(|| ServiceError::not_found("revision not found", Option::<String>::None))?;
+
+    if revision.status == REVISION_STATUS_APPLIED {
+        return Err(ServiceError::bad_request(
+            "revision has already been applied",
+        ));
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+
+    let target_entry_id = match revision.entry_id.clone() {
+        Some(entry_id) => {
+            entry::Entity::find_by_id(entry_id.clone())
+                .one(conn)
+                .await
+                .map_err(|db_err| {
+                    ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+                })?
+                .ok_or_else(|| {
+                    ServiceError::not_found(
+                        "the entry targeted by this revision no longer exists",
+                        Option::<String>::None,
+                    )
+                })?;
+
+            let mut update =
+                entry::Entity::update_many().filter(entry::Column::Id.eq(entry_id.clone()));
+            if let Some(unique_name) = revision.proposed_unique_name.clone() {
+                update = update.col_expr(entry::Column::UniqueName, Expr::value(unique_name));
+            }
+            if let Some(title) = revision.proposed_title.clone() {
+                update = update.col_expr(entry::Column::Title, Expr::value(title));
+            }
+            if let Some(content) = revision.proposed_content.clone() {
+                update = update.col_expr(entry::Column::Content, Expr::value(content));
+            }
+            update = update.col_expr(entry::Column::UpdatedAt, Expr::value(now));
+            update.exec(conn).await.map_err(|db_err| {
+                ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+            })?;
+
+            entry_id
+        }
+        None => {
+            let unique_name = revision.proposed_unique_name.clone().ok_or_else(|| {
+                ServiceError::bad_request(
+                    "applying a new-entry revision requires proposedUniqueName",
+                )
+            })?;
+            let title = revision.proposed_title.clone().ok_or_else(|| {
+                ServiceError::bad_request("applying a new-entry revision requires proposedTitle")
+            })?;
+
+            let new_entry = entry::Model {
+                id: uuid::Uuid::new_v4().to_string(),
+                unique_name,
+                title,
+                content: revision.proposed_content.clone(),
+                created_at: now,
+                updated_at: now,
+            };
+            let new_id = new_entry.id.clone();
+            entry::Entity::insert(new_entry.into_active_model())
+                .exec(conn)
+                .await
+                .map_err(|db_err| {
+                    ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+                })?;
+
+            new_id
+        }
+    };
+
+    entry_revision::Entity::update_many()
+        .col_expr(
+            entry_revision::Column::Status,
+            Expr::value(REVISION_STATUS_APPLIED.to_string()),
+        )
+        .col_expr(
+            entry_revision::Column::EntryId,
+            Expr::value(target_entry_id.clone()),
+        )
+        .col_expr(entry_revision::Column::UpdatedAt, Expr::value(now))
+        .filter(entry_revision::Column::Id.eq(revision.id.clone()))
+        .exec(conn)
+        .await
+        .map_err(|db_err| {
+            ServiceError::internal_server_error(INTERNAL_SERVER_ERROR, Some(db_err))
+        })?;
+
+    let mut applied = revision;
+    applied.status = REVISION_STATUS_APPLIED.to_string();
+    applied.entry_id = Some(target_entry_id);
+    applied.updated_at = now;
+
+    tracing::info!(revision_id = %applied.id, "Applied entry revision");
+    Ok(applied)
 }
 
 #[cfg(test)]
@@ -281,6 +406,145 @@ mod tests {
         let db = Database::from_connection(mock_db);
 
         let err = find_revisions(&db, None, None).await.unwrap_err();
+        assert!(matches!(err, ServiceError::InternalServerError(_)));
+    }
+
+    fn revision_model(entry_id: Option<&str>, status: &str) -> entry_revision::Model {
+        entry_revision::Model {
+            id: "rev-1".to_string(),
+            entry_id: entry_id.map(|s| s.to_string()),
+            proposed_unique_name: Some("avraham".to_string()),
+            proposed_title: Some("אברהם".to_string()),
+            proposed_content: Some("<p>תוכן</p>".to_string()),
+            source: "gpt-4o".to_string(),
+            notes: None,
+            status: status.to_string(),
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_revision_rejects_unknown_revision() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = apply_revision(&db, "missing".to_string())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_revision_rejects_already_applied() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                revision_model(Some("entry-1"), "APPLIED"),
+            ]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = apply_revision(&db, "rev-1".to_string()).await.unwrap_err();
+        assert!(matches!(err, ServiceError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_revision_new_entry_requires_unique_name() {
+        let mut revision = revision_model(None, "PENDING");
+        revision.proposed_unique_name = None;
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                revision,
+            ]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = apply_revision(&db, "rev-1".to_string()).await.unwrap_err();
+        assert!(matches!(err, ServiceError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_revision_creates_new_entry() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                revision_model(None, "PENDING"),
+            ]])
+            .append_exec_results([
+                MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+                MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+            ])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let applied = apply_revision(&db, "rev-1".to_string())
+            .await
+            .expect("revision should apply");
+
+        assert_eq!(applied.status, "APPLIED");
+        assert!(applied.entry_id.is_some());
+        assert!(!applied.entry_id.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_revision_updates_existing_entry() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                revision_model(Some("entry-1"), "PENDING"),
+            ]])
+            .append_query_results::<entry::Model, Vec<entry::Model>, _>([vec![entry_model(
+                "entry-1",
+            )]])
+            .append_exec_results([
+                MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+                MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+            ])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let applied = apply_revision(&db, "rev-1".to_string())
+            .await
+            .expect("revision should apply");
+
+        assert_eq!(applied.status, "APPLIED");
+        assert_eq!(applied.entry_id.as_deref(), Some("entry-1"));
+    }
+
+    #[tokio::test]
+    async fn apply_revision_rejects_when_target_entry_missing() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_results::<entry_revision::Model, Vec<entry_revision::Model>, _>([vec![
+                revision_model(Some("gone"), "PENDING"),
+            ]])
+            .append_query_results::<entry::Model, Vec<entry::Model>, _>([vec![]])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = apply_revision(&db, "rev-1".to_string()).await.unwrap_err();
+        assert!(matches!(err, ServiceError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_revision_surfaces_db_errors() {
+        let mock_db = MockDatabase::new(DatabaseBackend::MySql)
+            .append_query_errors([sea_orm::DbErr::Custom("boom".to_string())])
+            .into_connection();
+        let db = Database::from_connection(mock_db);
+
+        let err = apply_revision(&db, "rev-1".to_string()).await.unwrap_err();
         assert!(matches!(err, ServiceError::InternalServerError(_)));
     }
 }

--- a/web/api/src/startup/schema_builder.rs
+++ b/web/api/src/startup/schema_builder.rs
@@ -1,11 +1,13 @@
-use async_graphql::{EmptyMutation, EmptySubscription, MergedObject, Schema};
+use async_graphql::{EmptySubscription, MergedObject, Schema};
 
+use crate::common::auth::ApiAuth;
 use crate::providers::Database;
 use crate::resolvers::articles_resolver;
 use crate::resolvers::authors_resolver;
 use crate::resolvers::perakim_resolver;
 use crate::resolvers::sefarim_resolver;
 use crate::resolvers::starter_resolver;
+use crate::resolvers::tanahpedia_revisions_resolver;
 
 #[derive(MergedObject, Default)]
 pub struct QueryRoot(
@@ -14,12 +16,20 @@ pub struct QueryRoot(
     perakim_resolver::PerakimQuery,
     sefarim_resolver::SefarimQuery,
     starter_resolver::StarterQuery,
+    tanahpedia_revisions_resolver::TanahpediaRevisionsQuery,
 );
 
-pub fn build_schema(database: &Database) -> Schema<QueryRoot, EmptyMutation, EmptySubscription> {
-    Schema::build(QueryRoot::default(), EmptyMutation, EmptySubscription)
-        .data(database.to_owned())
-        .finish()
+#[derive(MergedObject, Default)]
+pub struct MutationRoot(tanahpedia_revisions_resolver::TanahpediaRevisionsMutation);
+
+pub fn build_schema(database: &Database) -> Schema<QueryRoot, MutationRoot, EmptySubscription> {
+    Schema::build(
+        QueryRoot::default(),
+        MutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(database.to_owned())
+    .finish()
 }
 
 use actix_web::{HttpRequest, HttpResponse, Result, web::Data};
@@ -31,12 +41,23 @@ use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 
 // ...
 
+/// Extracts a `Authorization: Bearer <token>` header value, if present.
+fn extract_bearer(req: &HttpRequest) -> Option<String> {
+    req.headers()
+        .get(actix_web::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
 pub async fn graphql_request(
-    schema: Data<Schema<QueryRoot, EmptyMutation, EmptySubscription>>,
-    _req: HttpRequest,
+    schema: Data<Schema<QueryRoot, MutationRoot, EmptySubscription>>,
+    req: HttpRequest,
     gql_req: GraphQLRequest,
 ) -> GraphQLResponse {
-    schema.execute(gql_req.into_inner()).await.into()
+    let auth = ApiAuth::new(extract_bearer(&req));
+    schema.execute(gql_req.into_inner().data(auth)).await.into()
 }
 
 pub async fn graphql_playground() -> Result<HttpResponse> {


### PR DESCRIPTION
## What

API-first interface so **external AI clients** can propose Tanahpedia entry revisions. Proposals land as `PENDING` rows for human triage in the Admin GUI and are **never auto-applied** to the live entry — going "API first" so the cute admin GUI just consumes this surface.

## Changes

- **Schema:** `tanahpedia_entry_revision` table (SQL + DBML) — a staging area decoupled from `tanahpedia_entry`; nullable `entry_id` (`ON DELETE CASCADE`) supports brand-new-entry proposals; `status` defaults to `PENDING`.
- **Entity/DTOs:** Sea-ORM `entry_revision` entity; `EntryRevision` (SimpleObject) + `SubmitEntryRevisionInput` (InputObject).
- **GraphQL:**
  - `submitEntryRevision(input)` mutation — **API-key gated**, fails closed.
  - `tanahpediaEntryRevisions(status, entryId)` triage query (newest-first).
- **Auth:** bearer token via `TANAHPEDIA_REVISION_API_KEY` (constant-time compare; unset/empty ⇒ `UNAUTHORIZED`).
- **Service:** validation (non-blank `source`, ≥1 `proposed_*` field, `entry_id` existence) + **11 unit tests** (service + auth) — all green.
- **Docs:** `docs/tanahpedia/external-revision-api.md` contract.

## Versioning

Bumps `web/api` `0.1.25 → 0.1.33` to clear the verify-version gate (highest `api-v*` tag 0.1.31, master HEAD 0.1.32).

## Config

Set `TANAHPEDIA_REVISION_API_KEY` in the API environment (`.env` / ECS task def). Endpoint fails closed when unset.

## Validation

- `cargo check --all-targets` / `cargo clippy --all-targets`: clean (0 warnings in new code).
- `cargo test --bin api`: **35 passed / 0 failed** (incl. 7 revision-service + 4 auth tests).

Base is the Tanahpedia integration branch (revision entity depends on tanahpedia entities not yet on master).