### PR TITLE
chore(bulletin): re-release 0.1.7 → 0.1.8 to restore CD Bulletin (green)

### DIFF
--- a/web/bulletin/Cargo.lock
+++ b/web/bulletin/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "bible-on-site-bulletin"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/web/bulletin/Cargo.toml
+++ b/web/bulletin/Cargo.toml
@@ -4,7 +4,7 @@ description = "Bible on Site PDF Bulletin Generator (AWS Lambda)"
 license-file = "../../license"
 repository = "https://github.com/bible-on-site/bible-on-site"
 publish = false
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Why
**CD Bulletin is STILL RED** — latest run [`27509915641`](https://github.com/bible-on-site/bible-on-site/actions/runs/27509915641) failed because the released Lambda ZIP artifact **expired** before the `deploy-bulletin` dispatch could download it (`actions/download-artifact` → *"Artifact has expired"*; the `digest-mismatch` line is a red-herring action input). PR #1714 already raised the bulletin artifact retention (1 → 90 days) to prevent recurrence — but a merged preventive fix does **not** clear the existing red. The badge reflects its *latest run* and only flips green on a **new successful bulletin release**.

## What
Version bump `web/bulletin` `0.1.7 → 0.1.8` (no functional change). Merging to master triggers `release_bulletin` (gated on `event_name == push && module_changed`), which builds a fresh **90-day-retention** artifact and re-fires the `deploy-bulletin` dispatch → Bulletin CD goes green.

## Gate
`0.1.8` > highest `bulletin-v*` tag (0.1.6) and > master HEAD (0.1.7) → verify-version passes.

## Note
**Merging is the prod action** (it cuts the release + deploy). Left for you to merge when ready. Refs #1711.